### PR TITLE
New connect API

### DIFF
--- a/lib/StoreProvider.spec.lua
+++ b/lib/StoreProvider.spec.lua
@@ -14,8 +14,17 @@ return function()
 
 		expect(element).to.be.ok()
 
-		Roact.reify(element, nil, "StoreProvider-test")
+		local handle = Roact.reify(element, nil, "StoreProvider-test")
 
+		Roact.teardown(handle)
 		store:destruct()
+	end)
+
+	it("should expect a 'store' prop", function()
+		local element = Roact.createElement(StoreProvider)
+
+		expect(function()
+			Roact.reify(element)
+		end).to.throw()
 	end)
 end

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -15,7 +15,10 @@ local function noop()
 end
 
 --[[
-	mapStateToProps: (storeState, props) -> partialProps
+	mapStateToProps:
+		(storeState, props) -> partialProps
+		OR
+		() -> (storeState, props) -> partialProps
 	mapDispatchToProps: (dispatch) -> partialProps
 ]]
 local function connect(mapStateToProps, mapDispatchToProps)

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -91,9 +91,7 @@ local function connect2(mapStateToProps, mapDispatchToProps)
 				local newStateValues = prevState.stateMapper(newStoreState, props)
 
 				if shallowEqual(newStateValues, prevState.stateValues) then
-					-- TODO: Return nil instead once Roblox/Roact#63 is closed
-					-- This will let us cancel the render.
-					return {}
+					return nil
 				end
 
 				local newCombinedState = join(props, newStateValues, prevState.dispatchValues)

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -18,7 +18,7 @@ end
 	mapStateToProps: (storeState, props) -> partialProps
 	mapDispatchToProps: (dispatch) -> partialProps
 ]]
-local function connect2(mapStateToProps, mapDispatchToProps)
+local function connect(mapStateToProps, mapDispatchToProps)
 	local connectTrace = debug.traceback()
 
 	if mapStateToProps ~= nil then
@@ -139,4 +139,4 @@ local function connect2(mapStateToProps, mapDispatchToProps)
 	end
 end
 
-return connect2
+return connect

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -90,7 +90,7 @@ local function connect(mapStateToProps, mapDispatchToProps)
 				stateValues = stateValues(storeState, self.props)
 			end
 
-			if typeof(stateValues) ~= "table" then
+			if stateValues ~= nil and typeof(stateValues) ~= "table" then
 				local message = formatMessage({
 					"mapStateToProps must either return a table, or return another function that returns a table.",
 					"Instead, it returned %q, which is of type %s.",

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -5,8 +5,12 @@ local function join(...)
 	local result = {}
 
 	for i = 1, select("#", ...) do
-		for key, value in pairs((select(i, ...))) do
-			result[key] = value
+		local source = select(i, ...)
+
+		if source ~= nil then
+			for key, value in pairs(source) do
+				result[key] = value
+			end
 		end
 	end
 
@@ -14,11 +18,25 @@ local function join(...)
 end
 
 --[[
-	A list comparison that's only valid if the given lists are the same length.
+	Transforms a list of keys and a map into a new map containing only those
 ]]
-local function listShallowEqual(a, b)
-	for index = 1, #a do
-		if a[index] ~= b[index] then
+local function selectKeysFromMap(keys, map)
+	local result = {}
+
+	for i = 1, #keys do
+		local key = keys[i]
+		result[key] = map[key]
+	end
+
+	return result
+end
+
+--[[
+	Compares two dictionaries, assuming that they have the same keys.
+]]
+local function oneWayShallowEqual(a, b)
+	for key, value in pairs(a) do
+		if value ~= b[key] then
 			return false
 		end
 	end
@@ -32,71 +50,103 @@ local function errorLines(...)
 end
 
 --[[
-	mapStateToProps(storeState, props) -> partialProps
-	mapDispatchToProps(dispatch) -> partialProps
+	options: {
+		mapStateToProps(storeState, props) -> partialProps
+		mapDispatchToProps(dispatch) -> partialProps
+	}
 ]]
-local function connect2(stateKeys, mapStateToProps, mapDispatchToProps)
-	-- TODO: validate mapStateToProps and mapDispatchToProps
+local function connect2(options)
+	local connectTrace = debug.traceback()
+
+	assert(typeof(options) == "table", "connect expects a table of options!")
+
+	local stateKeys = options.stateKeys
+	local mapStateToProps = options.mapStateToProps
+	local mapDispatchToProps = options.mapDispatchToProps
+
+	if stateKeys ~= nil and mapStateToProps == nil then
+		error("If 'stateKeys' is specified, 'mapStateToProps' must also be specified!", 2)
+	end
+
+	if mapStateToProps ~= nil and stateKeys == nil then
+		error("If 'mapStateToProps' is specified, 'stateKeys' must also be specified!", 2)
+	end
+
+	if stateKeys == nil and mapStateToProps == nil then
+		stateKeys = {}
+		mapStateToProps = function()
+			return nil
+		end
+	end
+
+	if mapDispatchToProps == nil then
+		mapDispatchToProps = function()
+			return nil
+		end
+	end
 
 	return function(innerComponent)
-		-- TODO: validate innerComponent
+		if innerComponent == nil then
+			local message = (
+				"connect returns a function that must be passed a component.\nCheck the connection at:\n%s"
+			):format(connectTrace)
+
+			error(message, 0)
+		end
 
 		local componentName = ("RoduxConnection(%s)"):format(tostring(innerComponent))
 
 		local outerComponent = Roact.Component:extend(componentName)
 
-		function outerComponent.getDerivedStateFromProps(props, state)
+		function outerComponent.getDerivedStateFromProps(nextProps, prevState)
+			local stateValues = mapStateToProps(prevState.storeStateSlice, nextProps)
+
 			return {
-				combinedState = join(props, state.stateValues, state.dispatchValues)
+				stateValues = join(nextProps, stateValues, prevState.dispatchValues)
 			}
 		end
 
 		function outerComponent:init()
 			local store = self._context[storeKey]
 
-			-- TODO: validate store
+			if store == nil then
+				errorLines(
+					"Cannot initialize Roact-Rodux connection without being a descendent of StoreProvider!",
+					("Tried to wrap component %q"):format(tostring(innerComponent)),
+					"Make sure there is a StoreProvider above this component in the tree."
+				)
+			end
 
 			self.store = store
 
-			local state = store:getState()
-			local relevantStoreState = {}
+			self.state = {}
 
-			for _, key in ipairs(stateKeys) do
-				relevantStoreState[key] = state[key]
-			end
+			self.state.storeStateSlice = selectKeysFromMap(stateKeys, store:getState())
+			self.state.stateValues = mapStateToProps(self.state.storeStateSlice)
 
-			self.relevantStoreState = relevantStoreState
-
-			if mapDispatchToProps then
-				state.dispatchValues = mapDispatchToProps(function(...)
-					self.store:dispatch(...)
-				end)
-			end
-
-			self.state = state
+			self.state.dispatchValues = mapDispatchToProps(function(...)
+				self.store:dispatch(...)
+			end)
 		end
 
-		function outerComponent:updateState(newRelevantStoreState)
-			self.relevantStoreState = newRelevantStoreState
+		function outerComponent:updateState(newStoreStateSlice)
+			self:setState(function(prevState, props)
+				local newState = mapStateToProps(newStoreStateSlice, self.props)
+				local stateValues = join(self.props, newState, self.dispatchValues)
 
-			local newState = mapStateToProps(self.props, unpack(newRelevantStoreState))
-			local combinedState = join(self.props, newState, self.dispatchValues)
-
-			self:setState({
-				combinedState = combinedState
-			})
+				return {
+					stateValues = stateValues,
+					storeStateSlice = newStoreStateSlice,
+				}
+			end)
 		end
 
 		function outerComponent:didMount()
-			self.eventHandle = self.store:connect(function(state)
-				local newStateValues = {}
+			self.eventHandle = self.store.changed:connect(function(state)
+				local newStateSlice = selectKeysFromMap(stateKeys, state)
 
-				for _, key in ipairs(stateKeys) do
-					newStateValues[key] = state[key]
-				end
-
-				if not listShallowEqual(newStateValues, self.stateValues) then
-					self:updateState(newStateValues)
+				if not oneWayShallowEqual(newStateSlice, self.storeStateSlice) then
+					self:updateState(newStateSlice)
 				end
 			end)
 		end
@@ -106,7 +156,7 @@ local function connect2(stateKeys, mapStateToProps, mapDispatchToProps)
 		end
 
 		function outerComponent:render()
-			return Roact.createElement(innerComponent, self.state.combinedState)
+			return Roact.createElement(innerComponent, self.state.stateValues)
 		end
 
 		return outerComponent

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -67,7 +67,7 @@ local function connect2(mapStateToProps, mapDispatchToProps)
 
 			local stateMapper = mapStateToProps
 
-			local stateValues = mapStateToProps(storeState)
+			local stateValues = mapStateToProps(storeState, self.props)
 			if typeof(stateValues) == "function" then
 				stateMapper = stateValues
 				stateValues = stateValues(storeState)

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -43,7 +43,7 @@ local function connect(mapStateToProps, mapDispatchToProps)
 				connectTrace,
 			})
 
-			error(message, 0)
+			error(message, 2)
 		end
 
 		local componentName = ("RoduxConnection(%s)"):format(tostring(innerComponent))
@@ -78,7 +78,6 @@ local function connect(mapStateToProps, mapDispatchToProps)
 			local storeState = self.store:getState()
 
 			local stateMapper = mapStateToProps
-
 			local stateValues = mapStateToProps(storeState, self.props)
 
 			-- mapStateToProps can return a function instead of a state value.

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -70,7 +70,7 @@ local function connect2(mapStateToProps, mapDispatchToProps)
 			local stateValues = mapStateToProps(storeState, self.props)
 			if typeof(stateValues) == "function" then
 				stateMapper = stateValues
-				stateValues = stateValues(storeState)
+				stateValues = stateValues(storeState, self.props)
 			end
 
 			local dispatchValues = mapDispatchToProps(function(...)

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -1,0 +1,116 @@
+local Roact = require(script.Parent.Parent.Roact)
+local storeKey = require(script.Parent.storeKey)
+
+local function join(...)
+	local result = {}
+
+	for i = 1, select("#", ...) do
+		for key, value in pairs((select(i, ...))) do
+			result[key] = value
+		end
+	end
+
+	return result
+end
+
+--[[
+	A list comparison that's only valid if the given lists are the same length.
+]]
+local function listShallowEqual(a, b)
+	for index = 1, #a do
+		if a[index] ~= b[index] then
+			return false
+		end
+	end
+
+	return true
+end
+
+-- A version of 'error' that outputs over multiple lines
+local function errorLines(...)
+	error(table.concat({...}, "\n"))
+end
+
+--[[
+	mapStateToProps(storeState, props) -> partialProps
+	mapDispatchToProps(dispatch) -> partialProps
+]]
+local function connect2(stateKeys, mapStateToProps, mapDispatchToProps)
+	-- TODO: validate mapStateToProps and mapDispatchToProps
+
+	return function(innerComponent)
+		-- TODO: validate innerComponent
+
+		local componentName = ("RoduxConnection(%s)"):format(tostring(innerComponent))
+
+		local outerComponent = Roact.Component:extend(componentName)
+
+		function outerComponent.getDerivedStateFromProps(props, state)
+			return {
+				combinedState = join(props, state.stateValues, state.dispatchValues)
+			}
+		end
+
+		function outerComponent:init()
+			local store = self._context[storeKey]
+
+			-- TODO: validate store
+
+			self.store = store
+
+			local state = store:getState()
+			local relevantStoreState = {}
+
+			for _, key in ipairs(stateKeys) do
+				relevantStoreState[key] = state[key]
+			end
+
+			self.relevantStoreState = relevantStoreState
+
+			if mapDispatchToProps then
+				state.dispatchValues = mapDispatchToProps(function(...)
+					self.store:dispatch(...)
+				end)
+			end
+
+			self.state = state
+		end
+
+		function outerComponent:updateState(newRelevantStoreState)
+			self.relevantStoreState = newRelevantStoreState
+
+			local newState = mapStateToProps(self.props, unpack(newRelevantStoreState))
+			local combinedState = join(self.props, newState, self.dispatchValues)
+
+			self:setState({
+				combinedState = combinedState
+			})
+		end
+
+		function outerComponent:didMount()
+			self.eventHandle = self.store:connect(function(state)
+				local newStateValues = {}
+
+				for _, key in ipairs(stateKeys) do
+					newStateValues[key] = state[key]
+				end
+
+				if not listShallowEqual(newStateValues, self.stateValues) then
+					self:updateState(newStateValues)
+				end
+			end)
+		end
+
+		function outerComponent:willUnmount()
+			self.eventHandle:disconnect()
+		end
+
+		function outerComponent:render()
+			return Roact.createElement(innerComponent, self.state.combinedState)
+		end
+
+		return outerComponent
+	end
+end
+
+return connect2

--- a/lib/connect2.spec.lua
+++ b/lib/connect2.spec.lua
@@ -6,7 +6,11 @@ return function()
 	local Roact = require(script.Parent.Parent.Roact)
 	local Rodux = require(script.Parent.Parent.Rodux)
 
-	local function incrementReducer(state, action)
+	local function noop()
+		return nil
+	end
+
+	local function countReducer(state, action)
 		state = state or 0
 
 		if action.type == "increment" then
@@ -16,76 +20,63 @@ return function()
 		return state
 	end
 
+	local reducer = Rodux.combineReducers({
+		count = countReducer,
+	})
+
 	describe("Argument validation", function()
-		it("should accept a table with stateKeys and mapStateToProps", function()
-			connect2({
-				stateKeys = {},
-				mapStateToProps = function()
-				end,
-			})
+		it("should accept no arguments", function()
+			connect2()
 		end)
 
-		it("should accept a table with mapDispatchToProps", function()
-			connect2({
-				mapDispatchToProps = function()
-				end,
-			})
+		it("should accept one function", function()
+			connect2(noop)
 		end)
 
-		it("should accept a table with stateKeys, mapStateToProps, and mapDispatchToProps", function()
-			connect2({
-				stateKeys = {},
-				mapStateToProps = function()
-				end,
-				mapDispatchToProps = function()
-				end,
-			})
+		it("should accept two functions", function()
+			connect2(noop, noop)
 		end)
 
-		it("should not accept zero parameters", function()
+		it("should accept only the second function", function()
+			connect2(nil, function() end)
+		end)
+
+		it("should throw if not passed a component", function()
+			local selector = function(store)
+				return {}
+			end
+
 			expect(function()
-				connect2()
-			end).to.throw()
-		end)
-
-		it("should not accept a table with stateKeys without mapStateToProps", function()
-			expect(function()
-				connect2({
-					stateKeys = {},
-				})
-			end).to.throw()
-		end)
-
-		it("should not accept a table with mapStateToProps without stateKeys", function()
-			expect(function()
-				connect2({
-					mapStateToProps = function()
-					end,
-				})
+				connect2(selector)(nil)
 			end).to.throw()
 		end)
 	end)
 
-	it("should throw if not passed a component", function()
-		local selector = function(store)
-			return {}
-		end
-
-		expect(function()
-			connect2(selector)(nil)
-		end).to.throw()
-	end)
-
-	it("should successfully connect when mounted under a StoreProvider", function()
-		local store = Rodux.Store.new(incrementReducer)
+	it("should connect when mounted under a StoreProvider", function()
+		local capturedProps
+		local store = Rodux.Store.new(reducer)
 
 		local function SomeComponent(props)
+			capturedProps = props
 			return nil
 		end
 
-		local ConnectedSomeComponent = connect2({}, function(store)
-			return {}
-		end)(SomeComponent)
+		local ConnectedSomeComponent = connect2(
+			function(state)
+				return {
+					count = state.count,
+				}
+			end,
+			function(dispatch)
+				return {
+					foo = function()
+						dispatch({
+							type = "increment"
+						})
+					end,
+				}
+			end
+		)(SomeComponent)
 
 		local tree = Roact.createElement(StoreProvider, {
 			store = store,
@@ -94,6 +85,20 @@ return function()
 		})
 
 		local handle = Roact.reify(tree)
+
+		expect(capturedProps.foo).to.be.a("function")
+		expect(capturedProps.count).to.equal(0)
+
+		local lastProps = capturedProps
+		local lastFoo = lastProps.foo
+
+		lastFoo()
+		store:flush()
+
+		expect(store:getState().count).to.equal(1)
+
+		expect(capturedProps.foo).to.equal(lastFoo)
+		expect(capturedProps.count).to.equal(1)
 
 		expect(handle).to.be.ok()
 	end)

--- a/lib/connect2.spec.lua
+++ b/lib/connect2.spec.lua
@@ -1,0 +1,100 @@
+return function()
+	local connect2 = require(script.Parent.connect2)
+
+	local StoreProvider = require(script.Parent.StoreProvider)
+
+	local Roact = require(script.Parent.Parent.Roact)
+	local Rodux = require(script.Parent.Parent.Rodux)
+
+	local function incrementReducer(state, action)
+		state = state or 0
+
+		if action.type == "increment" then
+			return state + 1
+		end
+
+		return state
+	end
+
+	describe("Argument validation", function()
+		it("should accept a table with stateKeys and mapStateToProps", function()
+			connect2({
+				stateKeys = {},
+				mapStateToProps = function()
+				end,
+			})
+		end)
+
+		it("should accept a table with mapDispatchToProps", function()
+			connect2({
+				mapDispatchToProps = function()
+				end,
+			})
+		end)
+
+		it("should accept a table with stateKeys, mapStateToProps, and mapDispatchToProps", function()
+			connect2({
+				stateKeys = {},
+				mapStateToProps = function()
+				end,
+				mapDispatchToProps = function()
+				end,
+			})
+		end)
+
+		it("should not accept zero parameters", function()
+			expect(function()
+				connect2()
+			end).to.throw()
+		end)
+
+		it("should not accept a table with stateKeys without mapStateToProps", function()
+			expect(function()
+				connect2({
+					stateKeys = {},
+				})
+			end).to.throw()
+		end)
+
+		it("should not accept a table with mapStateToProps without stateKeys", function()
+			expect(function()
+				connect2({
+					mapStateToProps = function()
+					end,
+				})
+			end).to.throw()
+		end)
+	end)
+
+	it("should throw if not passed a component", function()
+		local selector = function(store)
+			return {}
+		end
+
+		expect(function()
+			connect2(selector)(nil)
+		end).to.throw()
+	end)
+
+	it("should successfully connect when mounted under a StoreProvider", function()
+		local store = Rodux.Store.new(incrementReducer)
+
+		local function SomeComponent(props)
+			return nil
+		end
+
+		local ConnectedSomeComponent = connect2({}, function(store)
+			return {}
+		end)(SomeComponent)
+
+		local tree = Roact.createElement(StoreProvider, {
+			store = store,
+		}, {
+			Child = Roact.createElement(ConnectedSomeComponent),
+		})
+
+		local handle = Roact.reify(tree)
+
+		expect(handle).to.be.ok()
+	end)
+end

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1,7 +1,9 @@
 local StoreProvider = require(script.StoreProvider)
-local connect  = require(script.connect)
+local connect = require(script.connect)
+local connect2 = require(script.connect2)
 
 return {
 	StoreProvider = StoreProvider,
 	connect = connect,
+	UNSTABLE_connect2 = connect2,
 }

--- a/lib/join.lua
+++ b/lib/join.lua
@@ -1,0 +1,17 @@
+local function join(...)
+	local result = {}
+
+	for i = 1, select("#", ...) do
+		local source = select(i, ...)
+
+		if source ~= nil then
+			for key, value in pairs(source) do
+				result[key] = value
+			end
+		end
+	end
+
+	return result
+end
+
+return join

--- a/lib/shallowEqual.lua
+++ b/lib/shallowEqual.lua
@@ -1,4 +1,10 @@
 local function shallowEqual(a, b)
+	if a == nil then
+		return b == nil
+	elseif b == nil then
+		return a == nil
+	end
+
 	for key, value in pairs(a) do
 		if value ~= b[key] then
 			return false

--- a/lib/shallowEqual.lua
+++ b/lib/shallowEqual.lua
@@ -1,0 +1,17 @@
+local function shallowEqual(a, b)
+	for key, value in pairs(a) do
+		if value ~= b[key] then
+			return false
+		end
+	end
+
+	for key, value in pairs(b) do
+		if value ~= a[key] then
+			return false
+		end
+	end
+
+	return true
+end
+
+return shallowEqual


### PR DESCRIPTION
Fixes #1. Fixes #2.

This is a work-in-progress implementation of a new `connect` API. It's exposed as `UNSTABLE_connect2` right now.

The new API looks like this:

```
UNSTABLE_connect2(
    mapStateToProps,
    mapDispatchToProps
)
```

* `mapStateToProps` is a function that accepts the store's state and can either:
    * return a table containing props to merge
    * return a function that will be used as an instance-specific `mapStateToProps`. This is supported by react-redux and necessary to make selectors like Reselect work correctly.
* `mapDispatchToProps` receives the Store's `dispatch` function. It is only invoked once.