### PR TITLE
WIP: Introduce `StoreUpdateGate`, for temporarily blocking store updates for its descendants

### DIFF
--- a/lib/GatedSignal.lua
+++ b/lib/GatedSignal.lua
@@ -1,0 +1,107 @@
+--[[
+	A limited, simple implementation of a GatedSignal with the addition of a
+	gated condition.
+
+	If the signal has 'isBlocking' set, changes will be witheld until
+	'isBlocking' is reset to false..
+
+	Handlers are fired in order, and (dis)connections are properly handled when
+	executing an event.
+]]
+
+local function immutableAppend(list, ...)
+	local new = {}
+	local len = #list
+
+	for key = 1, len do
+		new[key] = list[key]
+	end
+
+	for i = 1, select("#", ...) do
+		new[len + i] = select(i, ...)
+	end
+
+	return new
+end
+
+local function immutableRemoveValue(list, removeValue)
+	local new = {}
+
+	for i = 1, #list do
+		if list[i] ~= removeValue then
+			table.insert(new, list[i])
+		end
+	end
+
+	return new
+end
+
+local GatedSignal = {}
+
+GatedSignal.__index = GatedSignal
+
+function GatedSignal.new()
+	local self = {
+		_listeners = {},
+		_isBlocking = false,
+		_shouldFireWhenUnblocked = false,
+	}
+
+	setmetatable(self, GatedSignal)
+
+	return self
+end
+
+function GatedSignal:connect(callback)
+	local listener = {
+		callback = callback,
+		disconnected = false,
+	}
+
+	self._listeners = immutableAppend(self._listeners, listener)
+
+	local function disconnect()
+		listener.disconnected = true
+		self._listeners = immutableRemoveValue(self._listeners, listener)
+	end
+
+	return {
+		disconnect = disconnect
+	}
+end
+
+function GatedSignal:fire(...)
+	if self._isBlocking then
+		self._shouldFireWhenUnblocked = true
+		return
+	end
+
+	for _, listener in ipairs(self._listeners) do
+		if not listener.disconnected then
+			listener.callback(...)
+		end
+	end
+end
+
+function GatedSignal:block()
+	if self._isBlocking then
+		return
+	end
+
+	self._isBlocking = true
+end
+
+function GatedSignal:unblock(...)
+	if not self._isBlocking then
+		return
+	end
+
+	self._isBlocking = false
+
+	if self._shouldFireWhenUnblocked then
+		self._shouldFireWhenUnblocked = false
+		self:fire(...)
+	end
+end
+
+return GatedSignal

--- a/lib/Signal.lua
+++ b/lib/Signal.lua
@@ -1,9 +1,5 @@
 --[[
-	A limited, simple implementation of a GatedSignal with the addition of a
-	gated condition.
-
-	If the signal has 'isBlocking' set, changes will be witheld until
-	'isBlocking' is reset to false..
+	A limited, simple implementation of a Signal.
 
 	Handlers are fired in order, and (dis)connections are properly handled when
 	executing an event.
@@ -36,23 +32,21 @@ local function immutableRemoveValue(list, removeValue)
 	return new
 end
 
-local GatedSignal = {}
+local Signal = {}
 
-GatedSignal.__index = GatedSignal
+Signal.__index = Signal
 
-function GatedSignal.new()
+function Signal.new()
 	local self = {
-		_listeners = {},
-		_isBlocking = false,
-		_shouldFireWhenUnblocked = false,
+		_listeners = {}
 	}
 
-	setmetatable(self, GatedSignal)
+	setmetatable(self, Signal)
 
 	return self
 end
 
-function GatedSignal:connect(callback)
+function Signal:connect(callback)
 	local listener = {
 		callback = callback,
 		disconnected = false,
@@ -70,12 +64,7 @@ function GatedSignal:connect(callback)
 	}
 end
 
-function GatedSignal:fire(...)
-	if self._isBlocking then
-		self._shouldFireWhenUnblocked = true
-		return
-	end
-
+function Signal:fire(...)
 	for _, listener in ipairs(self._listeners) do
 		if not listener.disconnected then
 			listener.callback(...)
@@ -83,25 +72,4 @@ function GatedSignal:fire(...)
 	end
 end
 
-function GatedSignal:block()
-	if self._isBlocking then
-		return
-	end
-
-	self._isBlocking = true
-end
-
-function GatedSignal:unblock(...)
-	if not self._isBlocking then
-		return
-	end
-
-	self._isBlocking = false
-
-	if self._shouldFireWhenUnblocked then
-		self._shouldFireWhenUnblocked = false
-		self:fire(...)
-	end
-end
-
-return GatedSignal
+return Signal

--- a/lib/Signal.spec.lua
+++ b/lib/Signal.spec.lua
@@ -1,0 +1,114 @@
+return function()
+	local Signal = require(script.Parent.Signal)
+
+	it("should construct from nothing", function()
+		local signal = Signal.new()
+
+		expect(signal).to.be.ok()
+	end)
+
+	it("should fire connected callbacks", function()
+		local callCount = 0
+		local value1 = "Hello World"
+		local value2 = 7
+
+		local callback = function(arg1, arg2)
+			expect(arg1).to.equal(value1)
+			expect(arg2).to.equal(value2)
+			callCount = callCount + 1
+		end
+
+		local signal = Signal.new()
+
+		local connection = signal:connect(callback)
+		signal:fire(value1, value2)
+
+		expect(callCount).to.equal(1)
+
+		connection:disconnect()
+		signal:fire(value1, value2)
+
+		expect(callCount).to.equal(1)
+	end)
+
+	it("should disconnect handlers", function()
+		local callback = function()
+			error("Callback was called after disconnect!")
+		end
+
+		local signal = Signal.new()
+
+		local connection = signal:connect(callback)
+		connection:disconnect()
+
+		signal:fire()
+	end)
+
+	it("should fire handlers in order", function()
+		local signal = Signal.new()
+		local x = 0
+		local y = 0
+
+		local callback1 = function()
+			expect(x).to.equal(0)
+			expect(y).to.equal(0)
+			x = x + 1
+		end
+
+		local callback2 = function()
+			expect(x).to.equal(1)
+			expect(y).to.equal(0)
+			y = y + 1
+		end
+
+		signal:connect(callback1)
+		signal:connect(callback2)
+		signal:fire()
+
+		expect(x).to.equal(1)
+		expect(y).to.equal(1)
+	end)
+
+	it("should continue firing despite mid-event disconnection", function()
+		local signal = Signal.new()
+		local countA = 0
+		local countB = 0
+
+		local connectionA
+		connectionA = signal:connect(function()
+			connectionA:disconnect()
+			countA = countA + 1
+		end)
+
+		signal:connect(function()
+			countB = countB + 1
+		end)
+
+		signal:fire()
+
+		expect(countA).to.equal(1)
+		expect(countB).to.equal(1)
+	end)
+
+	it("should skip listeners that were disconnected during event evaluation", function()
+		local signal = Signal.new()
+		local countA = 0
+		local countB = 0
+
+		local connectionB
+
+		signal:connect(function()
+			countA = countA + 1
+			connectionB:disconnect()
+		end)
+
+		connectionB = signal:connect(function()
+			countB = countB + 1
+		end)
+
+		signal:fire()
+
+		expect(countA).to.equal(1)
+		expect(countB).to.equal(0)
+	end)
+end

--- a/lib/StoreUpdateGate.lua
+++ b/lib/StoreUpdateGate.lua
@@ -40,7 +40,11 @@ function StoreUpdateGate:didUpdate(oldProps)
 		if self.props.shouldBlockUpdates then
 			self.stateAtLastBlock = self.realStore:getState()
 		else
-			self.mockStore.changed:fire(self.realStore:getState(), self.stateAtLastBlock)
+			local currentState = self.realStore:getState()
+
+			if currentState ~= self.stateAtLastBlock then
+				self.mockStore.changed:fire(currentState, self.stateAtLastBlock)
+			end
 		end
 	end
 end

--- a/lib/StoreUpdateGate.lua
+++ b/lib/StoreUpdateGate.lua
@@ -1,0 +1,76 @@
+local Roact = require(script.Parent.Parent.Roact)
+
+local storeKey = require(script.Parent.storeKey)
+local GatedSignal = require(script.Parent.GatedSignal)
+
+local StoreUpdateGate = Roact.Component:extend("StoreUpdateGate")
+
+function StoreUpdateGate:init()
+	local realStore = self._context[storeKey]
+
+	if not realStore then
+		error("StoreUpdateGate must be placed below a StoreProvider in the tree!")
+	end
+
+	-- The 'mock store' only exposes a subset of the real store's methods!
+	local mockStore = {}
+	mockStore.changed = GatedSignal.new()
+
+	mockStore.getState = function()
+		if self.props.shouldBlockUpdates then
+			return self.stateAtLastBlock
+		else
+			return realStore:getState()
+		end
+	end
+
+	mockStore.dispatch = function(self, action)
+		return realStore:dispatch(action)
+	end
+
+	self.changedConnection = realStore.changed:connect(function(...)
+		mockStore.changed:fire(...)
+	end)
+
+	self.mockStore = mockStore
+	self._context[storeKey] = mockStore
+
+	self.stateAtLastBlock = nil
+
+	if self.props.shouldBlockUpdates then
+		self:blockChanges()
+	end
+end
+
+function StoreUpdateGate:blockChanges()
+	self.stateAtLastBlock = self.mockStore:getState()
+	self.mockStore:block()
+end
+
+function StoreUpdateGate:unblockChanges()
+	local oldState = self.stateAtLastBlock
+	local newState = self.mockStore:getState()
+
+	self.stateAtLastBlock = nil
+	self.mockStore:unblock(oldState, newState)
+end
+
+function StoreUpdateGate:didUpdate(oldProps)
+	if self.props.shouldBlockUpdates ~= oldProps.shouldBlockUpdates then
+		if self.props.shouldBlockUpdates then
+			self:blockChanges()
+		else
+			self:unblockChanges()
+		end
+	end
+end
+
+function StoreUpdateGate:willUnmount()
+	self.changedConnection:disconnect()
+end
+
+function StoreUpdateGate:render()
+	return Roact.oneChild(self.props[Roact.Children])
+end
+
+return StoreUpdateGate

--- a/lib/StoreUpdateGate.spec.lua
+++ b/lib/StoreUpdateGate.spec.lua
@@ -1,0 +1,6 @@
+return function()
+	local Roact = require(script.Parent.Parent.Roact)
+	local StoreProvider = require(script.Parent.StoreProvider)
+
+	local StoreUpdateGate = require(script.Parent.StoreUpdateGate)
+end

--- a/lib/StoreUpdateGate.spec.lua
+++ b/lib/StoreUpdateGate.spec.lua
@@ -1,6 +1,89 @@
 return function()
 	local Roact = require(script.Parent.Parent.Roact)
+	local Rodux = require(script.Parent.Parent.Rodux)
+
 	local StoreProvider = require(script.Parent.StoreProvider)
+	local connect = require(script.Parent.connect2)
 
 	local StoreUpdateGate = require(script.Parent.StoreUpdateGate)
+
+	it("should throw if there is no StoreProvider above it", function()
+		local success, result = pcall(function()
+			return Roact.mount(Roact.createElement(StoreUpdateGate))
+		end)
+
+		expect(success).to.equal(false)
+		expect(result:find("StoreUpdateGate")).to.be.ok()
+		expect(result:find("StoreProvider")).to.be.ok()
+	end)
+
+	it("should allow store changes through when set to block", function()
+		local function reducer(state, action)
+			if state == nil then
+				state = 0
+			end
+
+			if action.type == "increment" then
+				return state + 1
+			end
+
+			return state
+		end
+
+		local store = Rodux.Store.new(reducer)
+
+		local lastProps
+		local function TestComponent(props)
+			lastProps = props
+			return nil
+		end
+
+		TestComponent = connect(
+			function(state)
+				return {
+					state = state,
+				}
+			end
+		)(TestComponent)
+
+		local function tree(shouldBlock)
+			return Roact.createElement(StoreProvider, {
+				store = store,
+			}, {
+				Blocker = Roact.createElement(StoreUpdateGate, {
+					shouldBlockUpdates = shouldBlock,
+				}, {
+					Child = Roact.createElement(TestComponent),
+				}),
+			})
+		end
+
+		local handle = Roact.mount(tree(false))
+
+		expect(lastProps).to.be.ok()
+		expect(lastProps.state).to.equal(0)
+
+		store:dispatch({ type = "increment" })
+		store:flush()
+
+		expect(lastProps.state).to.equal(1)
+
+		handle = Roact.reconcile(handle, tree(true))
+
+		store:dispatch({ type = "increment" })
+		store:flush()
+
+		expect(lastProps.state).to.equal(1)
+
+		handle = Roact.reconcile(handle, tree(false))
+
+		expect(lastProps.state).to.equal(2)
+
+		store:dispatch({ type = "increment" })
+		store:flush()
+
+		expect(lastProps.state).to.equal(3)
+
+		Roact.unmount(handle)
+	end)
 end


### PR DESCRIPTION
Closes #6.

Introduces a new component named `StoreUpdateGate` (name subject to change) that exposes a mock store for all connections below it in the tree.

The prop `shouldBlockUpdates` (name also subject to change) determines whether the `StoreUpdateGate` will pass on any Rodux store updates, or instead swallow them. When `shouldBlockUpdates` returns to `true` when it was previously `false`, a single update will be dispatched to all children.