### PR TITLE
Fix a typo in connect2

### DIFF
--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -131,7 +131,7 @@ local function connect(mapStateToProps, mapDispatchToProps)
 				return {
 					storeState = newStoreState,
 					stateValues = newStateValues,
-					combinedState = newCombinedState,
+					combinedValues = newCombinedState,
 				}
 			end)
 		end


### PR DESCRIPTION
This caused connect2 to depend on getDerivedStateFromProps being called when props did not change.