### PR TITLE
Rewrite connect2 to be a lot simpler

### DIFF
--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -14,6 +14,21 @@ local function noop()
 	return nil
 end
 
+local function makeStateUpdater(store, mapStateToProps)
+	return function(nextProps, prevState, mappedStoreState)
+		if mappedStoreState == nil then
+			mappedStoreState = mapStateToProps(store:getState(), nextProps)
+		end
+
+		local propsForChild = join(nextProps, mappedStoreState, prevState.mappedStoreDispatch)
+
+		return {
+			mappedStoreState = mappedStoreState,
+			propsForChild = propsForChild,
+		}
+	end
+end
+
 --[[
 	mapStateToProps:
 		(storeState, props) -> partialProps
@@ -47,21 +62,6 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 			})
 
 			error(message, 2)
-		end
-
-		local function makeStateUpdater(store, mapStateToProps)
-			return function(nextProps, prevState, mappedStoreState)
-				if mappedStoreState == nil then
-					mappedStoreState = mapStateToProps(store:getState(), nextProps)
-				end
-
-				local propsForChild = join(nextProps, mappedStoreState, prevState.mappedStoreDispatch)
-
-				return {
-					mappedStoreState = mappedStoreState,
-					propsForChild = propsForChild,
-				}
-			end
 		end
 
 		local componentName = ("RoduxConnection(%s)"):format(tostring(innerComponent))

--- a/lib/connect2.lua
+++ b/lib/connect2.lua
@@ -23,7 +23,7 @@ end
 	stateUpdater is put into the component's state in order for
 	getDerivedStateFromProps to be able to access it. It is not mutated.
 ]]
-local function makeStateUpdater(store, mapStateToProps)
+local function makeStateUpdater(store)
 	return function(nextProps, prevState, mappedStoreState)
 		-- The caller can optionally provide mappedStoreState if it needed that
 		-- value beforehand. Doing so is purely an optimization.


### PR DESCRIPTION
Closes #9.

There are a number of prop/state synchronization bugs in the current `connect2` implementation, one of which is outlined in #9. I'm essentially rewriting most of the interesting logic from the ground up.

I'm hoping to pattern some work based on https://github.com/reduxjs/react-redux/pull/919 but while also trying to keep the complexity low. React-Redux's `connectAdvanced` function seems significantly more complicated than we need.