### PR TITLE
Add UNSTABLE_getStore to get store directly from component instance

### DIFF
--- a/lib/connect.lua
+++ b/lib/connect.lua
@@ -1,5 +1,5 @@
 local Roact = require(script.Parent.Parent.Roact)
-local storeKey = require(script.Parent.storeKey)
+local getStore = require(script.Parent.getStore)
 local shallowEqual = require(script.Parent.shallowEqual)
 local join = require(script.Parent.join)
 
@@ -84,7 +84,7 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 		end
 
 		function Connection:init()
-			self.store = self._context[storeKey]
+			self.store = getStore(self)
 
 			if self.store == nil then
 				local message = formatMessage({

--- a/lib/getStore.lua
+++ b/lib/getStore.lua
@@ -1,0 +1,7 @@
+local storeKey = require(script.Parent.storeKey)
+
+local function getStore(componentInstance)
+	return componentInstance._context[storeKey]
+end
+
+return getStore

--- a/lib/getStore.spec.lua
+++ b/lib/getStore.spec.lua
@@ -1,0 +1,62 @@
+return function()
+	local Roact = require(script.Parent.Parent.Roact)
+	local Rodux = require(script.Parent.Parent.Rodux)
+
+	local StoreProvider = require(script.Parent.StoreProvider)
+
+	local getStore = require(script.Parent.getStore)
+
+	it("should return the store when present", function()
+		local function reducer()
+			return 0
+		end
+
+		local store = Rodux.Store.new(reducer)
+		local consumedStore = nil
+
+		local StoreConsumer = Roact.Component:extend("StoreConsumer")
+
+		function StoreConsumer:init()
+			consumedStore = getStore(self)
+		end
+
+		function StoreConsumer:render()
+			return nil
+		end
+
+		local tree = Roact.createElement(StoreProvider, {
+			store = store,
+		}, {
+			Consumer = Roact.createElement(StoreConsumer),
+		})
+
+		local handle = Roact.mount(tree)
+
+		expect(consumedStore).to.equal(store)
+
+		Roact.unmount(handle)
+		store:destruct()
+	end)
+
+	it("should return nil when the store is not present", function()
+		-- Use a non-nil value to know for sure if StoreConsumer:init was called
+		local consumedStore = 6
+
+		local StoreConsumer = Roact.Component:extend("StoreConsumer")
+
+		function StoreConsumer:init()
+			consumedStore = getStore(self)
+		end
+
+		function StoreConsumer:render()
+			return nil
+		end
+
+		local tree = Roact.createElement(StoreConsumer)
+		local handle = Roact.mount(tree)
+
+		expect(consumedStore).to.equal(nil)
+
+		Roact.unmount(handle)
+	end)
+end

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1,8 +1,10 @@
 local StoreProvider = require(script.StoreProvider)
 local connect = require(script.connect)
+local getStore = require(script.getStore)
 
 return {
 	StoreProvider = StoreProvider,
 	connect = connect,
+	UNSTABLE_getStore = getStore,
 	UNSTABLE_connect2 = connect,
 }


### PR DESCRIPTION
Fixes #12.

This PR adds `RoactRodux.UNSTABLE_getStore`, which enables retrieving the store from your component instance:

```lua
local Foo = Roact.Component:extend("Foo")

function Foo:init()
    print("The store is", RoactRodux.UNSTABLE_getStore(self))
end
```

TODO before submit:

- [x] Tests
- [x] ~Throw an error if the store isn't found?~ Nah.
- [x] Port `connect` to work in terms of `getStore`
- [ ] API documentation? This is unstable on purpose.