### PR TITLE
Fix bugs related to getDerivedStateFromProps in new reconciler

### DIFF
--- a/lib/connect.lua
+++ b/lib/connect.lua
@@ -80,7 +80,9 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 		local Connection = Roact.Component:extend(componentName)
 
 		function Connection.getDerivedStateFromProps(nextProps, prevState)
-			return prevState.stateUpdater(nextProps, prevState)
+			if prevState.stateUpdater ~= nil then
+				return prevState.stateUpdater(nextProps, prevState)
+			end
 		end
 
 		function Connection:init()
@@ -148,7 +150,11 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 				propsForChild = nil,
 			}
 
-			self.state.propsForChild = stateUpdater(self.props, self.state, mappedStoreState)
+			local extraState = stateUpdater(self.props, self.state, mappedStoreState)
+
+			for key, value in pairs(extraState) do
+				self.state[key] = value
+			end
 		end
 
 		function Connection:didMount()


### PR DESCRIPTION
The new reconciler has more consistent behavior with `getDerivedStateFromProps`.

This change should make Roact-Rodux work on both the current reconciler and the new one (once context lands in `new-reconciler`).