### PR TITLE
Fix incomplete connect uses in API reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -70,7 +70,7 @@ MyComponent = RoactRodux.connect(
 			end,
 		}
 	end
-)
+)(MyComponent)
 ```
 
 Using the higher-order version of `mapStateToProps`:
@@ -88,7 +88,7 @@ MyComponent = RoactRodux.connect(
 			}
 		end
 	end
-)
+)(MyComponent)
 ```
 
 The (very complicated) API signature of `connect` is:


### PR DESCRIPTION
The examples for `connect` are incomplete; they set up the connection function but don't actually create a component with them.

```lua
MyComponent = RoactRodux.connect(
    function(state, props)
        return {
            value = state.value,
        }
    end,
    function(dispatch)
        return {
            onClick = function()
                dispatch({
                    type = "increment",
                })
            end,
        }
    end
)
```

`MyComponent` is now a function with the signature `(component) -> wrappedComponent`, not an actual component. This fixes the examples.