### PR TITLE
Prepare 0.2.2 release instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Current master
 
-## 0.2.1 (2020-05-14)
+## 0.2.2 (2020-05-14)
 * Changed order of connection to store so that Parent components are connected to the store before their children.
 	* This should resolve some issues with components receiving bad combinations of props and store state.
+
+## 0.2.1 (2020-03-20)
+* Update to latest Rotriever manifest format.
 
 ## 0.2.0 (2019-10-24)
 * Initial release.

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -3,8 +3,8 @@ name = "roblox/roact-rodux"
 author = "Roblox"
 license = "Apache-2.0"
 content_root = "src"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
-Roact = "roblox/roact@1.2"
-Rodux = "roblox/rodux@1.0"
+Roact = "github.com/roblox/roact@1.2"
+Rodux = "github.com/roblox/rodux@1.0"


### PR DESCRIPTION
It looks like we already had released 0.2.1, oops!

This PR brings in a change to URL dependencies and bumps to 0.2.2.