### PR TITLE
Issue 27 Support multiple children for StoreProvider

### DIFF
--- a/src/StoreProvider.lua
+++ b/src/StoreProvider.lua
@@ -15,7 +15,7 @@ function StoreProvider:init(props)
 end
 
 function StoreProvider:render()
-	return Roact.oneChild(self.props[Roact.Children])
+	return Roact.createFragment(self.props[Roact.Children])
 end
 
 return StoreProvider


### PR DESCRIPTION
Issue: update StoreProvider:Render() to support fragments, replacing
Roact.oneChild with Roact.createFragment