### PR TITLE
LUAFDN-454 - Make result from `connect` a table

### DIFF
--- a/src/connect.lua
+++ b/src/connect.lua
@@ -203,16 +203,20 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 			return Roact.createElement(innerComponent, self.state.propsForChild)
 		end
 
-		return function(props)
+		local ConnectedComponent = Roact.Component:extend(componentName)
+
+		function ConnectedComponent:render()
 			return Roact.createElement(StoreContext.Consumer, {
 				render = function(store)
 					return Roact.createElement(Connection, {
-						innerProps = props,
+						innerProps = self.props,
 						store = store,
 					})
 				end
 			})
 		end
+
+		return ConnectedComponent
 	end
 end
 

--- a/src/connect.spec.lua
+++ b/src/connect.spec.lua
@@ -330,4 +330,23 @@ return function()
 
 		expect(childWasRenderedFirst).to.equal(false)
 	end)
+
+	it("should allow fields to be assigned on connected components", function()
+		local function mapStateToProps(state)
+			return {
+				count = state.count,
+			}
+		end
+
+		local ConnectedSomeComponent = connect(mapStateToProps)(NoopComponent)
+
+		expect(function()
+			ConnectedSomeComponent.SomeEnum = {
+				Value = 1,
+			}
+		end).never.to.throw()
+
+		expect(ConnectedSomeComponent.SomeEnum).to.be.ok()
+		expect(ConnectedSomeComponent.SomeEnum.Value).to.equal(1)
+	end)
 end


### PR DESCRIPTION
The result from `connect` became a function in 0.3.0. Instead, make it a table again to support certain use cases like:
```lua
local MyConnectedComponent = RoactRodux.connect(mapStateToProps)(MyComponent)
MyConnectedComponent.SomeConstant = 123

return MyConnectedComponent
```

This pattern is generally not encouraged, but sees use in legacy code.