### PR TITLE
Align package name to newer naming conventions

### DIFF
--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,5 +1,5 @@
 [package]
-name = "roblox/roact-rodux"
+name = "RoactRodux"
 author = "Roblox"
 license = "Apache-2.0"
 content_root = "src"


### PR DESCRIPTION
Small update before cutting 0.4.0; updating the package name to line up with newer conventions.