### PR TITLE
Use Roact.oneChild in StoreProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Unreleased Changes
 
+## 0.4.1 (2021-09-23)
+* Updated `StoreProvider` to accept `Roact.oneChild[self.props[Roact.Children]]` as its child, rather than `self.props[Roact.Children]` ([#55](https://github.com/Roblox/roact-rodux/pull/55))
+
 ## 0.4.0 (2021-09-02)
 * Fixed `connect` to always pass the right props, instead of sending the store to `mapDispatchToProps` ([#50](https://github.com/roblox/roact-rodux/pulls/50))
 * Change resulting component from `connect` back to a stateful component ([#49](https://github.com/roblox/roact-rodux/pulls/49))

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -3,7 +3,7 @@ name = "RoactRodux"
 author = "Roblox"
 license = "Apache-2.0"
 content_root = "src"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 Roact = "github.com/roblox/roact@1.4"

--- a/rotriever.toml
+++ b/rotriever.toml
@@ -1,5 +1,5 @@
 [package]
-name = "roblox/roact-rodux"
+name = "RoactRodux"
 author = "Roblox"
 license = "Apache-2.0"
 content_root = "src"

--- a/src/StoreProvider.lua
+++ b/src/StoreProvider.lua
@@ -19,7 +19,7 @@ end
 function StoreProvider:render()
 	return Roact.createElement(StoreContext.Provider, {
 		value = self.store,
-	}, self.props[Roact.Children])
+	}, Roact.oneChild(self.props[Roact.Children]))
 end
 
 return StoreProvider

--- a/src/StoreProvider.lua
+++ b/src/StoreProvider.lua
@@ -19,7 +19,9 @@ end
 function StoreProvider:render()
 	return Roact.createElement(StoreContext.Provider, {
 		value = self.store,
-	}, Roact.oneChild(self.props[Roact.Children]))
+	}, Roact.oneChild(
+		self.props[Roact.Children])
+	)
 end
 
 return StoreProvider

--- a/src/StoreProvider.lua
+++ b/src/StoreProvider.lua
@@ -20,8 +20,8 @@ function StoreProvider:render()
 	return Roact.createElement(StoreContext.Provider, {
 		value = self.store,
 	}, Roact.oneChild(
-		self.props[Roact.Children])
-	)
+		self.props[Roact.Children]
+	))
 end
 
 return StoreProvider

--- a/src/StoreProvider.spec.lua
+++ b/src/StoreProvider.spec.lua
@@ -28,7 +28,7 @@ return function()
 		end).to.throw()
 	end)
 
-	it("should accept multiple children", function()
+	it("should accept a single child", function()
 		local store = Rodux.Store.new(function()
 			return 0
 		end)
@@ -39,17 +39,15 @@ return function()
 			store = store,
 		}, {
 			test1 = Roact.createElement("Frame"),
-			test2 = Roact.createElement("Frame"),
-			test3 = Roact.createElement("Frame"),
 		})
 
 		expect(element).to.be.ok()
 
 		local handle = Roact.mount(element, folder, "StoreProvider-test")
 
-		expect(folder:FindFirstChild("test1")).to.be.ok()
-		expect(folder:FindFirstChild("test2")).to.be.ok()
-		expect(folder:FindFirstChild("test3")).to.be.ok()
+		local storeProviderChild = folder:FindFirstChild("StoreProvider-test", true)
+		expect(storeProviderChild).to.be.ok()
+		expect(storeProviderChild:IsA("Frame")).to.equal(true)
 
 		Roact.unmount(handle)
 		store:destruct()


### PR DESCRIPTION
StoreProvider should wrap children in Roact.oneChild. This allows for better compatibility with usage of Roact.mount(element, container, key). Users generally expect `key` to be applied to the element provided in Roact.mount, but this behavior is not guaranteed when just returning self.props[Roact.Children] in StoreProvider.