### PR TITLE
See if switching to the regular github token will fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
     - name: install code quality tools
       uses: rojo-rbx/setup-foreman@v1
       with:
-        version: "^1.0.0"
-        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        version: "^1.0.1"
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: code quality
       shell: bash


### PR DESCRIPTION
Seems to do the trick. This looks to have been misconfigured when stylua and the like were introduced.