### PR TITLE
Embed more information in the name of the Connector component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # Rotriever
 rotriever.lock
 Packages
+
+# Selene
+roblox.toml

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
 rojo = { source = "rojo-rbx/rojo", version = "6.2.0" }
 selene = { source = "Kampfkarren/selene", version = "0.14" }
-stylua = { source = "JohnnyMorganz/StyLua", version = "0.10.1" }
+stylua = { source = "JohnnyMorganz/StyLua", version = "0.11" }

--- a/src/ReactSymbols.lua
+++ b/src/ReactSymbols.lua
@@ -4,7 +4,7 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file at https://github.com/facebook/react/blob/a774502e0ff2a82e3c0a3102534dbc3f1406e5ea/LICENSE
  *
  * @flow
  ]]

--- a/src/ReactSymbols.lua
+++ b/src/ReactSymbols.lua
@@ -1,0 +1,37 @@
+-- upstream: https://github.com/facebook/react/blob/b61174fb7b09580c1ec2a8f55e73204b706d2935/packages/shared/ReactSymbols.js
+--!strict
+--[[*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ ]]
+
+-- ATTENTION
+-- When adding new symbols to this file,
+-- Please consider also adding to 'react-devtools-shared/src/backend/ReactSymbols'
+
+local exports = {
+	-- The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+	-- nor polyfill, then a plain number is used for performance.
+	REACT_ELEMENT_TYPE = 0xeac7,
+	REACT_PORTAL_TYPE = 0xeaca,
+	REACT_FRAGMENT_TYPE = 0xeacb,
+	REACT_STRICT_MODE_TYPE = 0xeacc,
+	REACT_PROFILER_TYPE = 0xead2,
+	REACT_PROVIDER_TYPE = 0xeacd,
+	REACT_CONTEXT_TYPE = 0xeace,
+	REACT_FORWARD_REF_TYPE = 0xead0,
+	REACT_SUSPENSE_TYPE = 0xead1,
+	REACT_SUSPENSE_LIST_TYPE = 0xead8,
+	REACT_MEMO_TYPE = 0xead3,
+	REACT_LAZY_TYPE = 0xead4,
+	REACT_SCOPE_TYPE = 0xead7,
+	REACT_OPAQUE_ID_TYPE = 0xeae0,
+	REACT_DEBUG_TRACING_MODE_TYPE = 0xeae1,
+	REACT_OFFSCREEN_TYPE = 0xeae2,
+	REACT_LEGACY_HIDDEN_TYPE = 0xeae3,
+	REACT_BINDING_TYPE = 0xeae4,
+}

--- a/src/connect.lua
+++ b/src/connect.lua
@@ -2,6 +2,7 @@ local Roact = require(script.Parent.Parent.Roact)
 local shallowEqual = require(script.Parent.shallowEqual)
 local join = require(script.Parent.join)
 local StoreContext = require(script.Parent.StoreContext)
+local getComponentName = require(script.Parent.getComponentName)
 
 --[[
 	Formats a multi-line message with printf-style placeholders.
@@ -79,7 +80,7 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 			error(message, 2)
 		end
 
-		local componentName = ("RoduxConnection(%s)"):format(tostring(innerComponent))
+		local componentName = ("RoduxConnection(%s)"):format(getComponentName(innerComponent))
 
 		local Connection = Roact.Component:extend(componentName)
 
@@ -115,7 +116,7 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 					"Tried to wrap component %q",
 					"Make sure there is a StoreProvider above this component in the tree.",
 				}, {
-					tostring(innerComponent),
+					getComponentName(innerComponent),
 				})
 
 				error(message)

--- a/src/getComponentName.lua
+++ b/src/getComponentName.lua
@@ -20,15 +20,17 @@ local REACT_STRICT_MODE_TYPE = ReactSymbols.REACT_STRICT_MODE_TYPE
 local REACT_SUSPENSE_TYPE = ReactSymbols.REACT_SUSPENSE_TYPE
 local REACT_SUSPENSE_LIST_TYPE = ReactSymbols.REACT_SUSPENSE_LIST_TYPE
 local REACT_LAZY_TYPE = ReactSymbols.REACT_LAZY_TYPE
-local REACT_BLOCK_TYPE = ReactSymbols.REACT_BLOCK_TYPE
 
 local getComponentName
 
 local function getWrappedName(outerType, innerType, wrapperName)
 	-- deviation: Account for indexing into function
 	local functionName = getComponentName(innerType)
-	return outerType.displayName
-		or (functionName ~= "" and string.format("%s(%s)", wrapperName, functionName) or wrapperName)
+	return outerType.displayName or (functionName ~= "" and string.format(
+		"%s(%s)",
+		wrapperName,
+		functionName
+	) or wrapperName)
 end
 
 local function getContextName(type)
@@ -43,7 +45,7 @@ function getComponentName(type)
 	local typeofType = typeof(type)
 
 	if typeofType == "function" then
-		local name = debug.info(type, "n")
+		local name = debug.info and debug.info(type, "n") or (debug.getinfo and debug.getinfo(type, "n").name)
 		-- when name = (null) we want it to be treated as nil, not as an empty (truthy) string
 		if name and #name > 0 then
 			return name

--- a/src/getComponentName.lua
+++ b/src/getComponentName.lua
@@ -26,11 +26,8 @@ local getComponentName
 local function getWrappedName(outerType, innerType, wrapperName)
 	-- deviation: Account for indexing into function
 	local functionName = getComponentName(innerType)
-	return outerType.displayName or (functionName ~= "" and string.format(
-		"%s(%s)",
-		wrapperName,
-		functionName
-	) or wrapperName)
+	return outerType.displayName
+		or (functionName ~= "" and string.format("%s(%s)", wrapperName, functionName) or wrapperName)
 end
 
 local function getContextName(type)

--- a/src/getComponentName.lua
+++ b/src/getComponentName.lua
@@ -1,0 +1,115 @@
+-- upstream: https://github.com/facebook/react/blob/a774502e0ff2a82e3c0a3102534dbc3f1406e5ea/packages/shared/getComponentName.js
+--[[*
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*
+* @flow
+]]
+
+local ReactSymbols = require(script.Parent.ReactSymbols)
+local REACT_CONTEXT_TYPE = ReactSymbols.REACT_CONTEXT_TYPE
+local REACT_FORWARD_REF_TYPE = ReactSymbols.REACT_FORWARD_REF_TYPE
+local REACT_FRAGMENT_TYPE = ReactSymbols.REACT_FRAGMENT_TYPE
+local REACT_PORTAL_TYPE = ReactSymbols.REACT_PORTAL_TYPE
+local REACT_MEMO_TYPE = ReactSymbols.REACT_MEMO_TYPE
+local REACT_PROFILER_TYPE = ReactSymbols.REACT_PROFILER_TYPE
+local REACT_PROVIDER_TYPE = ReactSymbols.REACT_PROVIDER_TYPE
+local REACT_STRICT_MODE_TYPE = ReactSymbols.REACT_STRICT_MODE_TYPE
+local REACT_SUSPENSE_TYPE = ReactSymbols.REACT_SUSPENSE_TYPE
+local REACT_SUSPENSE_LIST_TYPE = ReactSymbols.REACT_SUSPENSE_LIST_TYPE
+local REACT_LAZY_TYPE = ReactSymbols.REACT_LAZY_TYPE
+local REACT_BLOCK_TYPE = ReactSymbols.REACT_BLOCK_TYPE
+
+local getComponentName
+
+local function getWrappedName(outerType, innerType, wrapperName)
+	-- deviation: Account for indexing into function
+	local functionName = getComponentName(innerType)
+	return outerType.displayName
+		or (functionName ~= "" and string.format("%s(%s)", wrapperName, functionName) or wrapperName)
+end
+
+local function getContextName(type)
+	return type.displayName or "Context"
+end
+
+function getComponentName(type)
+	if type == nil then
+		-- Host root, text node or just invalid type.
+		return nil
+	end
+	local typeofType = typeof(type)
+
+	if typeofType == "function" then
+		local name = debug.info(type, "n")
+		-- when name = (null) we want it to be treated as nil, not as an empty (truthy) string
+		if name and #name > 0 then
+			return name
+		else
+			return nil
+		end
+	end
+
+	if typeofType == "string" then
+		return type
+	end
+
+	if type == REACT_FRAGMENT_TYPE then
+		return "Fragment"
+	elseif type == REACT_PORTAL_TYPE then
+		return "Portal"
+	elseif type == REACT_PROFILER_TYPE then
+		return "Profiler"
+	elseif type == REACT_STRICT_MODE_TYPE then
+		return "StrictMode"
+	elseif type == REACT_SUSPENSE_TYPE then
+		return "Suspense"
+	elseif type == REACT_SUSPENSE_LIST_TYPE then
+		return "SuspenseList"
+	end
+
+	if typeofType == "table" then
+		local typeProp = type["$$typeof"]
+		if typeProp == REACT_CONTEXT_TYPE then
+			local context = type
+			return getContextName(context) .. ".Consumer"
+		elseif typeProp == REACT_PROVIDER_TYPE then
+			local provider = type
+			return getContextName(provider._context) .. ".Provider"
+		elseif typeProp == REACT_FORWARD_REF_TYPE then
+			return getWrappedName(type, type.render, "ForwardRef")
+		elseif typeProp == REACT_MEMO_TYPE then
+			return getComponentName(type.type)
+		elseif typeProp == REACT_LAZY_TYPE then
+			local lazyComponent = type
+			local payload = lazyComponent._payload
+			local init = lazyComponent._init
+
+			local ok, result = pcall(init, payload)
+			if ok then
+				return getComponentName(result)
+			else
+				-- don't propagate error to avoid erroring during creation of error messages
+				return nil
+			end
+		else
+			if type.displayName then
+				return type.displayName
+			end
+			if type.name then
+				return type.name
+			end
+			-- only use tostring() if its overridden to avoid "table: 0xabcd9012"
+			local mt = getmetatable(type)
+			if mt and rawget(mt, "__tostring") then
+				return tostring(type)
+			end
+		end
+	end
+
+	return nil
+end
+
+return getComponentName

--- a/src/getComponentName.lua
+++ b/src/getComponentName.lua
@@ -3,7 +3,7 @@
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
-* LICENSE file in the root directory of this source tree.
+* LICENSE file at https://github.com/facebook/react/blob/a774502e0ff2a82e3c0a3102534dbc3f1406e5ea/LICENSE
 *
 * @flow
 ]]

--- a/src/getComponentName.lua
+++ b/src/getComponentName.lua
@@ -45,7 +45,9 @@ function getComponentName(type)
 	local typeofType = typeof(type)
 
 	if typeofType == "function" then
-		local name = debug.info and debug.info(type, "n") or (debug.getinfo and debug.getinfo(type, "n").name)
+		-- try using Roblox Lua's debug.info before falling back to lua5.1 debug.getinfo
+		-- selene: allow(incorrect_standard_library_use)
+		local name = type(debug.info) == "function" and debug.info(type, "n") or debug.getinfo(type, "n").source
 		-- when name = (null) we want it to be treated as nil, not as an empty (truthy) string
 		if name and #name > 0 then
 			return name

--- a/src/getComponentName.roblox.spec.lua
+++ b/src/getComponentName.roblox.spec.lua
@@ -1,0 +1,70 @@
+return function()
+	local Roact = require(script.Parent.Parent.Roact)
+	local getComponentName = require(script.Parent.getComponentName)
+	local ReactSymbols = require(script.Parent.ReactSymbols)
+
+	describe("function components", function()
+		local function MyComponent() end
+		local anonymous = function() end
+
+		it("gets name from non-anonymous function", function()
+			expect(getComponentName(MyComponent)).to.equal("MyComponent")
+		end)
+		it("gets nil from anonymous function", function()
+			local anonymous = function() end
+			expect(getComponentName(anonymous)).to.equal(nil)
+		end)
+	end)
+
+	describe("class components", function()
+		local MyClassComponent = Roact.Component:extend("MyClassComponent")
+
+		it("gets name from non-anonymous function", function()
+			expect(getComponentName(MyClassComponent)).to.equal("MyClassComponent")
+		end)
+		it("gets nil from unnamed component", function()
+			local unnamed = Roact.Component:extend("")
+			expect(getComponentName(unnamed)).to.equal(nil)
+		end)
+	end)
+
+	describe("React symbols", function()
+		it("fragment", function()
+			expect(getComponentName(ReactSymbols.REACT_FRAGMENT_TYPE)).to.equal("Fragment")
+		end)
+		it("Context without displayName", function()
+			local ContextComponent = {
+				["$$typeof"] = ReactSymbols.REACT_CONTEXT_TYPE,
+			}
+			expect(getComponentName(ContextComponent)).to.equal("Context.Consumer")
+		end)
+		it("Context with displayName", function()
+			local ContextComponent = {
+				["$$typeof"] = ReactSymbols.REACT_CONTEXT_TYPE,
+				displayName = "MyContext",
+			}
+			expect(getComponentName(ContextComponent)).to.equal("MyContext.Consumer")
+		end)
+		it("forward ref", function()
+			local function InnerComponent() end
+			local ForwardRefComponent = {
+				["$$typeof"] = ReactSymbols.REACT_FORWARD_REF_TYPE,
+				displayName = "MyForwardRef",
+				render = InnerComponent,
+			}
+			expect(getComponentName(ForwardRefComponent)).to.equal("ForwardRef(InnerComponent)")
+		end)
+	end)
+
+	describe("random tables", function()
+		local odd = newproxy(true)
+
+		getmetatable(odd).__tostring = function()
+			return "random table"
+		end
+
+		it("gets name from table with __tostring overriden", function()
+			expect(getComponentName(odd)).to.equal("random table")
+		end)
+	end)
+end


### PR DESCRIPTION
We are running into a rare issue in production where we need more information in the Roact-Rodux Connector component name to track it down.

This pulls in `getComponentName` and `ReactSymbols` from upstream React, and adds some basic tests around `getComponentName`. 

This should continue to be compatible with legacy Roact but we may want to do a major verison bump since it will interpret React fields on component classes, which may throw  when accessed if users have overridden `__newindex` or `__index` to throw.