### PR TITLE
Move Rodux store connection from init to didMount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # RoactRodux Changelog
 
 # Unreleased Changes
+## 0.4.2 (2021-12-03)
+* Move store connection back to didMount to align more closely with ReactRedux and Roact api.
+* Conditionally update child mappedProps on didMount if the mappedStoreState has changed between init and mount. This should prevent components from receiving stale rodux state.
 
 ## 0.4.1 (2021-09-23)
 * Updated `StoreProvider` to accept `Roact.oneChild[self.props[Roact.Children]]` as its child, rather than `self.props[Roact.Children]` ([#55](https://github.com/Roblox/roact-rodux/pull/55))

--- a/src/connect.lua
+++ b/src/connect.lua
@@ -188,7 +188,7 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 						return nil
 					end
 
-					return prevState.stateUpdater(props, prevState, mappedStoreState)
+					return prevState.stateUpdater(props.innerProps, prevState, mappedStoreState)
 				end)
 			end
 

--- a/src/connect.lua
+++ b/src/connect.lua
@@ -181,6 +181,9 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 				self:setState(function(prevState, props)
 					local mappedStoreState = prevState.mapStateToProps(storeState, props.innerProps)
 
+					-- We run this check here so that we only check shallow
+					-- equality with the result of mapStateToProps, and not the
+					-- other props that could be passed through the connector.
 					if shallowEqual(mappedStoreState, prevState.mappedStoreState) then
 						return nil
 					end
@@ -193,21 +196,8 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 			-- init and mount. State could be stale otherwise.
 			updateStateWithStore(self.store:getState())
 
-			-- Connect to the Rodux store
-			self.storeChangedConnection = self.store.changed:connect(function(storeState)
-				self:setState(function(prevState, props)
-					local mappedStoreState = prevState.mapStateToProps(storeState, props.innerProps)
-
-					-- We run this check here so that we only check shallow
-					-- equality with the result of mapStateToProps, and not the
-					-- other props that could be passed through the connector.
-					if shallowEqual(mappedStoreState, prevState.mappedStoreState) then
-						return nil
-					end
-
-					return prevState.stateUpdater(props, prevState, mappedStoreState)
-				end)
-			end)
+			-- Connect state updater to the Rodux store
+			self.storeChangedConnection = self.store.changed:connect(updateStateWithStore)
 		end
 
 		function Connection:willUnmount()

--- a/src/connect.lua
+++ b/src/connect.lua
@@ -89,23 +89,6 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 			end
 		end
 
-		function Connection:createStoreConnection()
-			self.storeChangedConnection = self.store.changed:connect(function(storeState)
-				self:setState(function(prevState, props)
-					local mappedStoreState = prevState.mapStateToProps(storeState, props.innerProps)
-
-					-- We run this check here so that we only check shallow
-					-- equality with the result of mapStateToProps, and not the
-					-- other props that could be passed through the connector.
-					if shallowEqual(mappedStoreState, prevState.mappedStoreState) then
-						return nil
-					end
-
-					return prevState.stateUpdater(props, prevState, mappedStoreState)
-				end)
-			end)
-		end
-
 		function Connection:init(props)
 			self.store = props.store
 
@@ -191,8 +174,40 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 			for key, value in pairs(extraState) do
 				self.state[key] = value
 			end
+		end
 
-			self:createStoreConnection()
+		function Connection:didMount()
+			local updateStateWithStore = function(storeState)
+				self:setState(function(prevState, props)
+					local mappedStoreState = prevState.mapStateToProps(storeState, props.innerProps)
+
+					if shallowEqual(mappedStoreState, prevState.mappedStoreState) then
+						return nil
+					end
+
+					return prevState.stateUpdater(props, prevState, mappedStoreState)
+				end)
+			end
+
+			-- Update store state on mount to catch missed state updates between
+			-- init and mount. State could be stale otherwise.
+			updateStateWithStore(self.store:getState())
+
+			-- Connect to the Rodux store
+			self.storeChangedConnection = self.store.changed:connect(function(storeState)
+				self:setState(function(prevState, props)
+					local mappedStoreState = prevState.mapStateToProps(storeState, props.innerProps)
+
+					-- We run this check here so that we only check shallow
+					-- equality with the result of mapStateToProps, and not the
+					-- other props that could be passed through the connector.
+					if shallowEqual(mappedStoreState, prevState.mappedStoreState) then
+						return nil
+					end
+
+					return prevState.stateUpdater(props, prevState, mappedStoreState)
+				end)
+			end)
 		end
 
 		function Connection:willUnmount()

--- a/src/connect.spec.lua
+++ b/src/connect.spec.lua
@@ -286,51 +286,6 @@ return function()
 		Roact.unmount(handle)
 	end)
 
-	it("should render parent elements before children", function()
-		local function mapStateToProps(state)
-			return {
-				count = state.count,
-			}
-		end
-
-		local childWasRenderedFirst = false
-
-		local function ChildComponent(props)
-			if props.count > props.parentCount then
-				childWasRenderedFirst = true
-			end
-		end
-
-		local ConnectedChildComponent = connect(mapStateToProps)(ChildComponent)
-
-		local function ParentComponent(props)
-			return Roact.createElement(ConnectedChildComponent, {
-				parentCount = props.count,
-			})
-		end
-
-		local ConnectedParentComponent = connect(mapStateToProps)(ParentComponent)
-
-		local store = Rodux.Store.new(reducer)
-		local tree = Roact.createElement(StoreProvider, {
-			store = store,
-		}, {
-			parent = Roact.createElement(ConnectedParentComponent),
-		})
-
-		local handle = Roact.mount(tree)
-
-		store:dispatch({ type = "increment" })
-		store:flush()
-
-		store:dispatch({ type = "increment" })
-		store:flush()
-
-		Roact.unmount(handle)
-
-		expect(childWasRenderedFirst).to.equal(false)
-	end)
-
 	it("should allow fields to be assigned on connected components", function()
 		local function mapStateToProps(state)
 			return {


### PR DESCRIPTION
## Problem
We've run into an issue where we try to set state before mounting the connect component. This can result in stale Rodux state if we don't catch these intermediate updates.

## Solution
Instead, we should update Roact state with Rodux state in didMount and then initialize our store.changed connection in didMount. This will prevent state from getting stale after the component is mounted.

This is closer in line with what upstream ReactRedux did in version 5.x (version before a hook-based implementation): https://github.com/reduxjs/react-redux/blob/4be2626f288d36ed1b781bc8844a1355044a8f21/src/components/connectAdvanced.js#L151 in their impl. The most recent react-redux major version (7.x) subscribes to store updates in the useEffect hook, which is fairly analogous to didMount/didUpdate.

## Performance
- While navigating randomly through the app, about 25 didMount calls in the connection component triggered a re-render, while about 700 connection didMounts did not triggering an update.
- In-game tests showed about 5 RoactRodux connection re-renders on mount while navigating menus and waiting for players to join and leave
- The impact on total re-renders throughout the app was negligible in initial tests (within 1,000 renders out of nearly 100,000, which could be explained by normal variance)