### PR TITLE
Move traceback call in connect()

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
-rojo = { source = "rojo-rbx/rojo", version = "6.2.0" }
-selene = { source = "Kampfkarren/selene", version = "0.14" }
-stylua = { source = "JohnnyMorganz/StyLua", version = "0.10.1" }
+rojo = { source = "rojo-rbx/rojo", version = "=7.2.1" }
+selene = { source = "Kampfkarren/selene", version = "=0.21.1" }
+stylua = { source = "JohnnyMorganz/StyLua", version = "=0.15.1" }

--- a/src/StoreProvider.lua
+++ b/src/StoreProvider.lua
@@ -19,9 +19,7 @@ end
 function StoreProvider:render()
 	return Roact.createElement(StoreContext.Provider, {
 		value = self.store,
-	}, Roact.oneChild(
-		self.props[Roact.Children]
-	))
+	}, Roact.oneChild(self.props[Roact.Children]))
 end
 
 return StoreProvider

--- a/src/connect.lua
+++ b/src/connect.lua
@@ -48,8 +48,6 @@ end
 	mapDispatchToProps: (dispatch) -> partialProps
 ]]
 local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
-	local connectTrace = debug.traceback()
-
 	if mapStateToPropsOrThunk ~= nil then
 		assert(typeof(mapStateToPropsOrThunk) == "function", "mapStateToProps must be a function or nil!")
 	else
@@ -68,6 +66,7 @@ local function connect(mapStateToPropsOrThunk, mapDispatchToProps)
 
 	return function(innerComponent)
 		if innerComponent == nil then
+			local connectTrace = debug.traceback()
 			local message = formatMessage({
 				"connect returns a function that must be passed a component.",
 				"Check the connection at:",


### PR DESCRIPTION
Moves traceback call in connect() under the condition where we actually throw an error so we don't have to call it for every invocation.