### PR TITLE
APT-606 - Change Foreman To Install Internal Mirrors Instead Of External Tools APT-578 Upgrade setup-foreman to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         submodules: true
 
     - name: Install foreman tools
-      uses: Roblox/setup-foreman@v1
+      uses: Roblox/setup-foreman@v3
       with:
         version: "^1.0.1"
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
         luarocks install luacov-reporter-lcov
 
     - name: install code quality tools
-      uses: Roblox/setup-foreman@v1
+      uses: Roblox/setup-foreman@v3
       with:
         version: "^1.0.1"
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We should use setup-foreman v3 to enforce that tools installed by Foreman in CI come from Roblox repos

[_Created by Sourcegraph batch change `afujiwara/APT-578-upgrade-all-setup-foreman-actions-in-ci`._](https://sourcegraph.rbx.com/users/afujiwara/batch-changes/APT-578-upgrade-all-setup-foreman-actions-in-ci)